### PR TITLE
fix: Oracle now uses https for JDK links

### DIFF
--- a/tasks/install_java.yml
+++ b/tasks/install_java.yml
@@ -6,7 +6,7 @@
       changed_when: false
 
     - name: get latest url
-      shell: cat /tmp/links | grep -ioE 'http://download.oracle.com/otn-pub/java/jdk/.*?/jdk-8u.*?-linux-x64.tar.gz' | tail -1
+      shell: cat /tmp/links | grep -ioE 'http.?://download.oracle.com/otn-pub/java/jdk/.*?/jdk-8u.*?-linux-x64.tar.gz' | tail -1
       register: JVM_URL
       changed_when: false
 


### PR DESCRIPTION
Hello Moshe! We recently noticed this role doesn't work anymore because Oracle changed the URLs protocol, so here's a fix that might help you as well. Travis build fails though for ubuntu distro, not sure why - sounds like smth completely irrelevant. I've also tried older versions of ansible-run (2.8) and ubuntu docker image (3.1.1?) that were working at https://travis-ci.org/moshloop/ansible-java/jobs/397759389 - same thing.